### PR TITLE
Fixes lag within MMultiplayerScreen.java

### DIFF
--- a/src/main/java/io/github/techstreet/dfscript/mixin/render/MMultiplayerScreen.java
+++ b/src/main/java/io/github/techstreet/dfscript/mixin/render/MMultiplayerScreen.java
@@ -21,8 +21,8 @@ public class MMultiplayerScreen extends Screen {
         super(title);
     }
 
-    @Inject(at = @At("HEAD"), method = "render", cancellable = true)
-    private void render(MatrixStack matrices, int mouseX, int mouseY, float delta, CallbackInfo ci) {
+    @Inject(at = @At("HEAD"), method = "init", cancellable = true)
+    private void init(CallbackInfo ci) {
         this.addDrawableChild(new BlendableTexturedButtonWidget(5, 5, 20, 20, 0, 0, 20, identifier_main, 20, 40, (button) -> {
             ScriptListScreen screen = new ScriptListScreen(false);
             DFScript.MC.setScreen(screen);


### PR DESCRIPTION
Fixes client sided lag, make sure to only call render IF you are rendering it to the scene, not adding it!

Waiting inside of the Multiplayer screen for too long lags out the game because of the times it has to render the button for each call (EX: 1st render renders the button, 2nd renders 2 buttons, and so on...)